### PR TITLE
config/secrets.ymlにシンボリックリンクを貼る

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -13,6 +13,7 @@ set :bundle_binstubs, nil
 set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets bundle public/system public/assets}
 set :default_env, { path: "usr/local/rbenv/shims:/usr/local/rbenv/bin:$PATH" }
 set :keep_releases, 5
+set :linked_files, %w{ config/secrets.yml }
 
 namespace :deploy do
   after :finishing, 'deploy:cleanup'


### PR DESCRIPTION
サーバ上では、current/config/secrets.ymlのファイルは
シンボリックリンク化する。
実際のファイルは shared/config/secrets.ymlに用意する。
